### PR TITLE
zookeeper statefulset

### DIFF
--- a/statefulset/zk-configmap.yaml
+++ b/statefulset/zk-configmap.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-configmap
+data:
+  start-zk.sh: |
+    HOST=`hostname -s`
+    DOMAIN=`hostname -d`
+    if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then
+        NAME=${BASH_REMATCH[1]}
+        ORD=${BASH_REMATCH[2]}
+    else
+        echo "Fialed to parse name and ordinal of Pod"
+        exit 1
+    fi
+
+    function list_servers() {
+      for (( i=1; i<=$1; i++ ))
+      do
+          echo "server.$i=$NAME-$((i-1)).$DOMAIN:2888:3888"
+      done
+    }
+
+    # `NODE_COUNT` need to match with `replicas` in `zk-statefulset.yaml`
+    NODE_COUNT=3
+    export ZOO_MY_ID=$((ORD+1))
+    export ZOO_SERVERS=`list_servers $NODE_COUNT`
+    /docker-entrypoint.sh
+    zkServer.sh start-foreground
+  
+  liveness-check.sh: |
+    echo ruok | nc localhost 2181 | grep imok
+    
+  readiness-check.sh: |
+    RETRY=12
+    if nslookup $(hostname -f | sed -e 's/default.svc.cluster.local//') ; then
+      rm /tmp/dns-check.log
+      echo stat | nc localhost 2181 | grep Zxid
+    elif [[ $(wc -l </tmp/readiness-check.log) -lt ${RETRY} ]]; then
+      echo 'DNS not ready' >> /tmp/dns-check.log
+    else
+      echo "retry reach ${RETRY}" >> /tmp/dns-check.log
+      exit 1
+    fi
+

--- a/statefulset/zk-statefulset.yaml
+++ b/statefulset/zk-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
                   - key: "app"
                     operator: In
                     values:
-                    - zk-hs
+                    - zk
               topologyKey: "kubernetes.io/hostname"
       containers:
       - name: kubernetes-zookeeper

--- a/statefulset/zk-statefulset.yaml
+++ b/statefulset/zk-statefulset.yaml
@@ -1,0 +1,121 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zk-hs
+  labels:
+    app: zk
+spec:
+  ports:
+  - port: 2888
+    name: server
+  - port: 3888
+    name: leader-election
+  clusterIP: None
+  selector:
+    app: zk
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zk-cs
+  labels:
+    app: zk
+spec:
+  ports:
+  - port: 2181
+    name: client
+  selector:
+    app: zk
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: zk-pdb
+spec:
+  selector:
+    matchLabels:
+      app: zk
+  # maxUnavailable calculate from `replicas`
+  maxUnavailable: 1
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: zk
+spec:
+  selector:
+    matchLabels:
+      app: zk
+  serviceName: zk-hs
+  # need to change `NODE_COUNT` in `zk-configmap.yaml` to equal number of replicas
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: zk
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                    - zk-hs
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+      - name: kubernetes-zookeeper
+        image: "zookeeper"
+        resources:
+          requests:
+            memory: "1.0Gi"
+            cpu: "0.3"
+        ports:
+        - containerPort: 2181
+          name: client
+        - containerPort: 2888
+          name: server
+        - containerPort: 3888
+          name: leader-election
+        command:
+        - bash
+        - /tmp/script/start-zk.sh
+        readinessProbe:
+          exec:
+            command:
+            - bash
+            - /tmp/script/readiness-check.sh
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - /tmp/script/liveness-check.sh
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: datadir
+          mountPath: /var/lib/zookeeper
+        - name: start-script
+          mountPath: /tmp/script
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
+      volumes:
+      - name: start-script
+        configMap:
+          name: script-configmap
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
Change
======
- from manually create pods to statefulset controller & template
- client port (2181) from headless service to service
- remove env and pvc for datalog dir

Add
===
- PodDisruptionBudget
- readinessProbe
- livenessProbe
- securityContext
- pod affinity
- script for config and start zookeeper in statefulset (start-zk.sh)